### PR TITLE
Fix #81: reinstate Lootr compatibility.

### DIFF
--- a/src/main/java/xiroc/dungeoncrawl/dungeon/model/DungeonModelFeature.java
+++ b/src/main/java/xiroc/dungeoncrawl/dungeon/model/DungeonModelFeature.java
@@ -97,7 +97,7 @@ public final class DungeonModelFeature {
         world.setBlock(pos, chest, 2);
         TileEntity tileEntity = world.getBlockEntity(pos);
         if (tileEntity instanceof LockableLootTileEntity) {
-            Loot.setLoot((LockableLootTileEntity) tileEntity, Loot.getLootTable(lootLevel, rand), theme, secondaryTheme, rand);
+            Loot.setLoot(world, pos, (LockableLootTileEntity) tileEntity, Loot.getLootTable(lootLevel, rand), theme, secondaryTheme, rand);
         }
     }
 

--- a/src/main/java/xiroc/dungeoncrawl/dungeon/piece/DungeonPiece.java
+++ b/src/main/java/xiroc/dungeoncrawl/dungeon/piece/DungeonPiece.java
@@ -314,9 +314,9 @@ public abstract class DungeonPiece extends StructurePiece {
         TileEntity tile = world.getBlockEntity(pos);
         if (tile instanceof LockableLootTileEntity) {
             if (model.hasLootTable()) {
-                Loot.setLoot((LockableLootTileEntity) tile, model.getLootTable(), theme, secondaryTheme, rand);
+                Loot.setLoot(world, pos, (LockableLootTileEntity) tile, model.getLootTable(), theme, secondaryTheme, rand);
             } else {
-                Loot.setLoot((LockableLootTileEntity) tile, Loot.getLootTable(stage, rand), theme, secondaryTheme, rand);
+                Loot.setLoot(world, pos, (LockableLootTileEntity) tile, Loot.getLootTable(stage, rand), theme, secondaryTheme, rand);
             }
         }
 

--- a/src/main/java/xiroc/dungeoncrawl/dungeon/treasure/Loot.java
+++ b/src/main/java/xiroc/dungeoncrawl/dungeon/treasure/Loot.java
@@ -21,8 +21,11 @@ package xiroc.dungeoncrawl.dungeon.treasure;
 import net.minecraft.loot.LootTables;
 import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.tileentity.LockableLootTileEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.Tuple;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.IWorld;
 import xiroc.dungeoncrawl.DungeonCrawl;
 import xiroc.dungeoncrawl.theme.Theme;
 
@@ -57,8 +60,8 @@ public class Loot {
 
     public static final ResourceLocation WITHER_SKELETON = DungeonCrawl.locate("monster_overrides/wither_skeleton");
 
-    public static void setLoot(LockableLootTileEntity tile, ResourceLocation lootTable, Theme theme, Theme.SecondaryTheme secondaryTheme, Random rand) {
-        tile.setLootTable(lootTable, rand.nextLong());
+    public static void setLoot(IWorld world, BlockPos pos, LockableLootTileEntity tile, ResourceLocation lootTable, Theme theme, Theme.SecondaryTheme secondaryTheme, Random rand) {
+        LockableLootTileEntity.setLootTable(world, rand, pos, lootTable);
         setLootInformation(tile.getTileData(), theme, secondaryTheme);
     }
 


### PR DESCRIPTION
Convert `Loot`'s loot table setting to accept world & blockpos
meaning the function can once again use the static setLootTable method
from the LockableLootTileEntity.